### PR TITLE
Fix TTL Preset for 1 month to be 30 days instead of 30 months

### DIFF
--- a/app/Embed/Cache.php
+++ b/app/Embed/Cache.php
@@ -71,7 +71,7 @@ class Cache
     public static function getTtlPresets(): array
     {
         return [
-            MONTH_IN_SECONDS * 30 => __('1 month', 'iframely'),
+            DAY_IN_SECONDS * 30 => __('1 month', 'iframely'),
             WEEK_IN_SECONDS * 3 => __('3 weeks', 'iframely'),
             WEEK_IN_SECONDS * 2 => __('2 weeks', 'iframely'),
             WEEK_IN_SECONDS => __('1 week', 'iframely'),

--- a/app/Embed/Cache.php
+++ b/app/Embed/Cache.php
@@ -71,7 +71,7 @@ class Cache
     public static function getTtlPresets(): array
     {
         return [
-            DAY_IN_SECONDS * 30 => __('1 month', 'iframely'),
+            MONTH_IN_SECONDS => __('1 month', 'iframely'),
             WEEK_IN_SECONDS * 3 => __('3 weeks', 'iframely'),
             WEEK_IN_SECONDS * 2 => __('2 weeks', 'iframely'),
             WEEK_IN_SECONDS => __('1 week', 'iframely'),


### PR DESCRIPTION
Currently the 1 Month preset actually sets the TTL to 30 months. This PR removes the `30` multiplier to make the preset accurately be a month.